### PR TITLE
Implement streaming chat endpoint

### DIFF
--- a/backend/app/analyzer.py
+++ b/backend/app/analyzer.py
@@ -116,6 +116,30 @@ class DataAnalyzer:
 
         return response.choices[0].message.content.strip()
 
+    def data_chat_stream(self, user_query, chat_history=None):
+        if not user_query:
+            yield ""
+            return
+
+        prompt = self.prompt_manager.data_chat_prompt(user_query)
+
+        message_history = [{"role": "system", "content": "You are a smart and friendly data assistant."}]
+        if chat_history:
+            message_history += [{"role": role, "content": content} for role, content in chat_history]
+
+        message_history.append({"role": "user", "content": prompt})
+
+        stream = self.client.chat.completions.create(
+            model="gpt-4-turbo",
+            messages=message_history,
+            stream=True,
+        )
+
+        for chunk in stream:
+            delta = chunk.choices[0].delta.content
+            if delta:
+                yield delta
+
     def data_describe(self):
         return self.df.describe().round(2).to_dict()
 


### PR DESCRIPTION
## Summary
- add `data_chat_stream` to Analyzer for streaming token results
- expose new `/chat_stream` FastAPI endpoint using `StreamingResponse`

## Testing
- `python -m py_compile backend/app/analyzer.py backend/app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa4038688833080fa6d2c94f1bd38