### PR TITLE
Add futuristic Next.js homepage with components

### DIFF
--- a/frontend/infra-beta/app/globals.css
+++ b/frontend/infra-beta/app/globals.css
@@ -1,2 +1,5 @@
 @import "tailwindcss";
 
+body {
+  @apply bg-black text-white font-sans;
+}

--- a/frontend/infra-beta/app/page.jsx
+++ b/frontend/infra-beta/app/page.jsx
@@ -1,11 +1,13 @@
-import Image from "next/image";
+import dynamic from 'next/dynamic';
+
+const Hero = dynamic(() => import('../components/Hero'));
+const Features = dynamic(() => import('../components/Features'));
 
 export default function Home() {
   return (
-    <div className="">
-      <main className="">
-        <p>Hello world</p>
-      </main>
+    <div className="bg-black min-h-screen">
+      <Hero />
+      <Features />
     </div>
   );
 }

--- a/frontend/infra-beta/components/Features.jsx
+++ b/frontend/infra-beta/components/Features.jsx
@@ -1,0 +1,38 @@
+import { FaTools, FaCloud, FaLock } from 'react-icons/fa';
+
+const features = [
+  {
+    icon: FaTools,
+    title: 'Automation',
+    description: 'Streamline your workflows with powerful automation tools.'
+  },
+  {
+    icon: FaCloud,
+    title: 'Scalability',
+    description: 'Scale seamlessly with cloud-native infrastructure.'
+  },
+  {
+    icon: FaLock,
+    title: 'Security',
+    description: 'Protect your data with enterprise-grade security.'
+  }
+];
+
+export default function Features() {
+  return (
+    <section className="py-20 bg-gray-950 text-white">
+      <div className="max-w-5xl mx-auto grid md:grid-cols-3 gap-12 px-8">
+        {features.map((feature) => {
+          const Icon = feature.icon;
+          return (
+            <div key={feature.title} className="text-center">
+              <Icon className="text-4xl mx-auto mb-4 text-purple-400" />
+              <h3 className="text-xl font-semibold mb-2">{feature.title}</h3>
+              <p className="text-gray-400">{feature.description}</p>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/infra-beta/components/Hero.jsx
+++ b/frontend/infra-beta/components/Hero.jsx
@@ -1,0 +1,13 @@
+import { FaRocket } from 'react-icons/fa';
+
+export default function Hero() {
+  return (
+    <section className="min-h-screen flex flex-col justify-center items-center bg-gradient-to-br from-gray-900 via-purple-900 to-black text-center text-white p-8">
+      <FaRocket className="text-6xl mb-6 animate-bounce" />
+      <h1 className="text-5xl font-extrabold mb-4">Welcome to Infra-Beta</h1>
+      <p className="max-w-xl text-lg text-gray-300">
+        Explore the future of infrastructure management with cutting edge tools and seamless integrations.
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- create Hero and Features components under `components`
- apply base styling in `globals.css`
- update `page.jsx` to use the new components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa48093148330b0886141bd2bdba4