### PR TITLE
Add login/register pages

### DIFF
--- a/frontend/infra-beta/app/layout.jsx
+++ b/frontend/infra-beta/app/layout.jsx
@@ -12,7 +12,11 @@ export default function RootLayout({ children }) {
       <body
         className={`antialiased`}
       >
-        {children}
+        <nav className="p-4 bg-gray-100 flex gap-4">
+          <a href="/login" className="text-blue-600">Login</a>
+          <a href="/register" className="text-blue-600">Register</a>
+        </nav>
+        <div className="p-4">{children}</div>
       </body>
     </html>
   );

--- a/frontend/infra-beta/app/login/page.jsx
+++ b/frontend/infra-beta/app/login/page.jsx
@@ -1,0 +1,56 @@
+'use client';
+import { useState } from 'react';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const body = new URLSearchParams();
+      body.append('username', email);
+      body.append('password', password);
+      const res = await fetch('http://localhost:8000/auth/jwt/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      });
+      if (!res.ok) throw new Error('Login failed');
+      await res.json();
+      alert('Logged in!');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2 w-full"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 w-full"
+          required
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/infra-beta/app/register/page.jsx
+++ b/frontend/infra-beta/app/register/page.jsx
@@ -1,0 +1,55 @@
+'use client';
+import { useState } from 'react';
+
+export default function RegisterPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+    try {
+      const res = await fetch('http://localhost:8000/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) throw new Error('Registration failed');
+      setSuccess(true);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">Register</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2 w-full"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 w-full"
+          required
+        />
+        {error && <p className="text-red-500">{error}</p>}
+        {success && <p className="text-green-600">User created!</p>}
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
+          Register
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add React login and register pages for FastAPI backend
- add nav links in layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa4a171208330abb65db21a18aaae