### PR TITLE
Add login and protected dashboard

### DIFF
--- a/frontend/infra-beta/app/dashboard/page.jsx
+++ b/frontend/infra-beta/app/dashboard/page.jsx
@@ -1,0 +1,36 @@
+'use client'
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function Dashboard() {
+  const router = useRouter();
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const storedUser = localStorage.getItem('user');
+    if (!storedUser) {
+      router.replace('/login');
+    } else {
+      setUser(storedUser);
+    }
+  }, [router]);
+
+  const handleLogout = () => {
+    localStorage.removeItem('user');
+    router.push('/login');
+  };
+
+  if (!user) return null;
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Welcome, {user}!</h1>
+      <button
+        onClick={handleLogout}
+        className="p-2 bg-red-500 text-white rounded"
+      >
+        Log Out
+      </button>
+    </div>
+  );
+}

--- a/frontend/infra-beta/app/login/page.jsx
+++ b/frontend/infra-beta/app/login/page.jsx
@@ -1,0 +1,51 @@
+'use client'
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (username) {
+      // Save user in localStorage to persist login
+      localStorage.setItem('user', username);
+      router.push('/dashboard');
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <div>
+          <label className="block mb-2">Username</label>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-2">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full p-2 border rounded"
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full p-2 bg-blue-500 text-white rounded"
+        >
+          Log In
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/infra-beta/app/page.jsx
+++ b/frontend/infra-beta/app/page.jsx
@@ -1,10 +1,37 @@
+'use client'
 import Image from "next/image";
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 export default function Home() {
+  const router = useRouter();
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      setUser(stored);
+    }
+  }, []);
+
+  const goToDashboard = () => {
+    if (user) {
+      router.push('/dashboard');
+    } else {
+      router.push('/login');
+    }
+  };
+
   return (
-    <div className="">
-      <main className="">
+    <div className="p-4">
+      <main className="space-y-4">
         <p>Hello world</p>
+        <button
+          onClick={goToDashboard}
+          className="p-2 bg-green-500 text-white rounded"
+        >
+          {user ? 'Go to Dashboard' : 'Login'}
+        </button>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `/login` page to store username and persist it in `localStorage`
- add `/dashboard` page that redirects to login if user info is missing
- update home page to link to login or dashboard depending on stored user

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa51b287c8330bcace2dcce121ed7