### PR TITLE
Improve front‑end design

### DIFF
--- a/frontend/infra-beta/app/globals.css
+++ b/frontend/infra-beta/app/globals.css
@@ -1,2 +1,6 @@
 @import "tailwindcss";
 
+body {
+  @apply bg-gradient-to-br from-blue-50 to-indigo-100 text-gray-800 min-h-screen;
+}
+

--- a/frontend/infra-beta/app/layout.jsx
+++ b/frontend/infra-beta/app/layout.jsx
@@ -1,4 +1,7 @@
 import "./globals.css";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"] });
 
 
 export const metadata = {
@@ -9,14 +12,15 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body
-        className={`antialiased`}
-      >
-        <nav className="p-4 bg-gray-100 flex gap-4">
-          <a href="/login" className="text-blue-600">Login</a>
-          <a href="/register" className="text-blue-600">Register</a>
+      <body className={`${inter.className} antialiased`}>
+        <nav className="bg-white shadow-sm">
+          <div className="max-w-4xl mx-auto flex items-center gap-6 p-4">
+            <a href="/" className="font-semibold text-gray-700">Home</a>
+            <a href="/login" className="text-blue-600 hover:underline">Login</a>
+            <a href="/register" className="text-blue-600 hover:underline">Register</a>
+          </div>
         </nav>
-        <div className="p-4">{children}</div>
+        <div className="p-4 max-w-4xl mx-auto">{children}</div>
       </body>
     </html>
   );

--- a/frontend/infra-beta/app/login/page.jsx
+++ b/frontend/infra-beta/app/login/page.jsx
@@ -27,30 +27,35 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="max-w-md mx-auto mt-10">
-      <h1 className="text-2xl font-bold mb-4">Login</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="border p-2 w-full"
-          required
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="border p-2 w-full"
-          required
-        />
-        {error && <p className="text-red-500">{error}</p>}
-        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
-          Login
-        </button>
-      </form>
+    <div className="flex items-center justify-center mt-10">
+      <div className="w-full max-w-md bg-white p-8 rounded-lg shadow">
+        <h1 className="text-2xl font-semibold text-center mb-6">Login</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded focus:ring-blue-500 focus:border-blue-500"
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded focus:ring-blue-500 focus:border-blue-500"
+            required
+          />
+          {error && <p className="text-red-500">{error}</p>}
+          <button
+            type="submit"
+            className="w-full bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            Login
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/frontend/infra-beta/app/page.jsx
+++ b/frontend/infra-beta/app/page.jsx
@@ -22,22 +22,34 @@ export default function Home() {
   };
 
   return (
-    <div className="p-4">
-      <form onSubmit={handleSubmit} className="space-y-2">
-        <input type="file" onChange={(e) => setFile(e.target.files?.[0])} />
-        <input
-          type="text"
-          className="border p-1"
-          placeholder="Ask a question"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-        />
-        <button type="submit" className="px-3 py-1 bg-blue-500 text-white">
-          Send
-        </button>
-      </form>
-      {response && <p className="mt-4">{response}</p>}
-      {error && <p className="mt-4 text-red-500">{error}</p>}
+    <div className="mt-10">
+      <h1 className="text-3xl font-bold mb-6 text-center">Chat with your PDF</h1>
+      <div className="bg-white rounded-lg shadow p-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="file"
+            className="block w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer focus:outline-none bg-gray-50 p-2"
+            onChange={(e) => setFile(e.target.files?.[0])}
+          />
+          <input
+            type="text"
+            className="w-full border border-gray-300 p-2 rounded focus:ring-blue-500 focus:border-blue-500"
+            placeholder="Ask a question"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            Send
+          </button>
+        </form>
+        {response && (
+          <p className="mt-4 text-gray-700 whitespace-pre-line">{response}</p>
+        )}
+        {error && <p className="mt-4 text-red-500">{error}</p>}
+      </div>
     </div>
   );
 }

--- a/frontend/infra-beta/app/register/page.jsx
+++ b/frontend/infra-beta/app/register/page.jsx
@@ -25,31 +25,36 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="max-w-md mx-auto mt-10">
-      <h1 className="text-2xl font-bold mb-4">Register</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="border p-2 w-full"
-          required
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="border p-2 w-full"
-          required
-        />
-        {error && <p className="text-red-500">{error}</p>}
-        {success && <p className="text-green-600">User created!</p>}
-        <button type="submit" className="bg-blue-600 text-white px-4 py-2">
-          Register
-        </button>
-      </form>
+    <div className="flex items-center justify-center mt-10">
+      <div className="w-full max-w-md bg-white p-8 rounded-lg shadow">
+        <h1 className="text-2xl font-semibold text-center mb-6">Register</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded focus:ring-blue-500 focus:border-blue-500"
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded focus:ring-blue-500 focus:border-blue-500"
+            required
+          />
+          {error && <p className="text-red-500">{error}</p>}
+          {success && <p className="text-green-600">User created!</p>}
+          <button
+            type="submit"
+            className="w-full bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            Register
+          </button>
+        </form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- upgrade the layout to use the Inter font and nicer nav
- add gradient background styling
- refresh the home page card UI
- modernize login and register forms

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683face5a1f083309f687384cd897d31