### PR TITLE
Add setup script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Infra-beta
+
+This repository contains a Python backend built with FastAPI and a Next.js frontend.
+
+## Setup
+
+Run `setup.sh` to install Python and Node.js dependencies:
+
+```bash
+./setup.sh
+```
+
+## Backend
+
+The backend code resides in the `backend/` directory. Start the server using:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Frontend
+
+Navigate to `frontend/infra-beta` and run the development server:
+
+```bash
+npm run dev
+```
+
+## Linting
+
+To lint the frontend code, run:
+
+```bash
+npm run lint --prefix frontend/infra-beta
+```
+
+Make sure dependencies are installed beforehand.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Simple setup script to install backend and frontend dependencies
+
+# Install Python dependencies
+if [ -f backend/requirements.txt ]; then
+    echo "Installing Python packages..."
+    pip install -r backend/requirements.txt || exit 1
+fi
+
+# Install Node.js dependencies
+if [ -f frontend/infra-beta/package.json ]; then
+    echo "Installing frontend packages..."
+    npm install --prefix frontend/infra-beta || exit 1
+fi
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add project README with setup instructions
- add setup.sh to install backend and frontend dependencies

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `npm run lint --prefix frontend/infra-beta` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa8f30bac8330bdc174428ac28683